### PR TITLE
Issue#3 fix

### DIFF
--- a/src/ninemensmorris/networking/NMMClientThread.java
+++ b/src/ninemensmorris/networking/NMMClientThread.java
@@ -34,27 +34,40 @@ public class NMMClientThread extends Thread {
             ObjectOutputStream poos = new ObjectOutputStream(socket.getOutputStream());
             ObjectInputStream pois = new ObjectInputStream(socket.getInputStream());
             Scanner input = new Scanner(System.in);
-
-            while (socket.isConnected()) {
+            int itr = 1;
+            while (true) {
                 NMMmove move = null;
+                //ObjectInputStream pois = new ObjectInputStream(socket.getInputStream());
                 
-                try {
-                    NMMboard board = (NMMboard) pois.readObject();
+                //try {
+                NMMboard board = null;
+                    for(int i=0; i<itr; i++)
+                    {
+                        System.out.println("Bytes: =" + pois.available());
+                        board = (NMMboard) pois.readObject();   
+                    }
                     NMMLogic.cmdPrint(board.getNmmBoard(), PrintType.VALUE);
                     System.out.println(board.getNmmBoard());
                     
                     System.out.print("Enter Move: ");
                     move = new NMMmove(input.nextLine());
-                } catch (ClassNotFoundException ex) {
+                /*} catch (ClassNotFoundException ex) {
                     Logger.getLogger(NMMClientThread.class.getName()).log(Level.SEVERE, null, ex);
-                }
+                }*/
 
                 poos.writeObject(move);
+                //pois.close();
+                itr++;
+                itr = itr>2?2:2;
             }
 
-            socket.close();
+            //socket.close();
         } catch (IOException ex) {
-        }
+            Logger.getLogger(NMMClientThread.class.getName()).log(Level.SEVERE, null, ex);
+            System.out.println("dang, excepted");
+        } catch (ClassNotFoundException ex) {
+            Logger.getLogger(NMMClientThread.class.getName()).log(Level.SEVERE, null, ex);
+        } 
     }
 
 }

--- a/src/ninemensmorris/networking/NMMServiceThread.java
+++ b/src/ninemensmorris/networking/NMMServiceThread.java
@@ -54,11 +54,14 @@ public class NMMServiceThread extends Thread {
 
                             //Sends the board
                             NMMboard board = new NMMboard(nmm.nmmBoard);
+                            //debug statement, remove later
                             System.out.println("NmmBoard: "+ nmm.nmmBoard[0][0].getCoinInt());
-                            p1oos.writeObject(board);
-                            p2oos.writeObject(board);
+                            p1oos.writeObject(board); //sends board to p1
+                            p2oos.writeObject(board); //sends board to p2
+                            //flushes outputstream
                             p1oos.flush();
                             p2oos.flush();
+                            //prints the baord
                             nmm.cmdPrint(PrintType.VALUE);
 
                             NMMmove move;
@@ -70,7 +73,8 @@ public class NMMServiceThread extends Thread {
                                     move = (NMMmove) p2ois.readObject();
                                     break;
                                 default:    //Error
-                                    move = new NMMmove("A1");
+                                    move = new NMMmove("A1"); 
+                                    //Consider throwing exception here
                                     break;
                             }
 

--- a/src/ninemensmorris/networking/NMMServiceThread.java
+++ b/src/ninemensmorris/networking/NMMServiceThread.java
@@ -15,6 +15,7 @@ import java.util.logging.Logger;
 import ninemensmorris.NMMCoin;
 import ninemensmorris.NMMLogic;
 import ninemensmorris.NMMLogicDemo;
+import ninemensmorris.enums.MCoinType;
 import ninemensmorris.enums.PlayerTurn;
 import ninemensmorris.enums.PrintType;
 
@@ -56,8 +57,15 @@ public class NMMServiceThread extends Thread {
                             NMMboard board = new NMMboard(nmm.nmmBoard);
                             //debug statement, remove later
                             System.out.println("NmmBoard: "+ nmm.nmmBoard[0][0].getCoinInt());
-                            p1oos.writeObject(board); //sends board to p1
-                            p2oos.writeObject(board); //sends board to p2
+                            if(nmm.getMenLeft() == 9)
+                                nmm.nmmBoard[0][0].setCoin(MCoinType.WHITE);
+                            else
+                                nmm.nmmBoard[0][1].setCoin(MCoinType.BLACK);
+                            
+                            p1oos.reset();
+                            p2oos.reset();
+                            p1oos.writeUnshared(board); //sends board to p1
+                            p2oos.writeUnshared(board); //sends board to p2
                             //flushes outputstream
                             p1oos.flush();
                             p2oos.flush();

--- a/src/ninemensmorris/networking/demo/NMMServerDemo.java
+++ b/src/ninemensmorris/networking/demo/NMMServerDemo.java
@@ -25,7 +25,7 @@ public class NMMServerDemo {
         try {
             ServerSocket ssocket = new ServerSocket(9999);
             System.out.println("Server Listening");
-
+            
             // TODO: Implement Thread Pool
             while (true) {
                 Socket p1 = ssocket.accept();


### PR DESCRIPTION
Patch Closes #3 . The ObjectOutputStream would write new Objects with the same reference. Therefore the ObjectInputStream would read the same reference over and over again. Fixed by calling `writeUnshared()` or `reset()` on the ObjectOutputStream.